### PR TITLE
Potential fix for code scanning alert no. 1: Shell command built from environment values

### DIFF
--- a/scripts/init.mjs
+++ b/scripts/init.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 
-import { execSync } from "node:child_process";
+import { execSync, execFileSync } from "node:child_process";
 import { dirname, join } from "node:path";
 import { mkdir } from "node:fs/promises";
 import { program } from "commander";
@@ -128,7 +128,7 @@ program
             await mkdir(tempDir);
 
             log(chalk.blue("Cloning pho-monorepo..."));
-            execSync(`git clone ${url} ${tempDir}`, execSyncOpts);
+            execFileSync("git", ["clone", url, tempDir], execSyncOpts);
             process.chdir(tempDir);
 
             log(chalk.blue(`Checking out version ${from}...`));


### PR DESCRIPTION
Potential fix for [https://github.com/divineniiquaye/pho-monorepo/security/code-scanning/1](https://github.com/divineniiquaye/pho-monorepo/security/code-scanning/1)

To fix the problem, we should avoid constructing the shell command dynamically with potentially tainted values. Instead, we can use the `execFileSync` function, which allows us to pass arguments separately from the command itself. This approach ensures that the arguments are not interpreted by the shell, preventing command injection vulnerabilities.

We need to:
1. Replace the dynamic command construction with `execFileSync`.
2. Pass the `url` and `tempDir` as separate arguments to the `git clone` command.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
